### PR TITLE
adding AEMS to list of solvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Many packages use the POMDPs.jl interface, including MDP and POMDP solvers, supp
 | [MCVI](https://github.com/JuliaPOMDP/MCVI.jl) | [![Build Status](https://travis-ci.org/JuliaPOMDP/MCVI.jl.svg?branch=master)](https://travis-ci.org/JuliaPOMDP/MCVI.jl) | [![Coverage Status](https://coveralls.io/repos/github/JuliaPOMDP/MCVI.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaPOMDP/MCVI.jl?branch=master) |
 | [POMDPSolve](https://github.com/JuliaPOMDP/POMDPSolve.jl)* | [![Build Status](https://travis-ci.org/JuliaPOMDP/POMDPSolve.jl.svg?branch=master)](https://travis-ci.org/JuliaPOMDP/POMDPSolve.jl) | [![Coverage Status](https://coveralls.io/repos/JuliaPOMDP/POMDPSolve.jl/badge.svg)](https://coveralls.io/r/JuliaPOMDP/POMDPSolve.jl) |
 | [POMCPOW](https://github.com/JuliaPOMDP/POMCPOW.jl) | [![Build Status](https://travis-ci.org/JuliaPOMDP/POMCPOW.jl.svg?branch=master)](https://travis-ci.org/JuliaPOMDP/POMCPOW.jl) | [![Coverage Status](https://coveralls.io/repos/github/JuliaPOMDP/POMCPOW.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaPOMDP/POMCPOW.jl?branch=master) |
+| [AEMS](https://github.com/JuliaPOMDP/AEMS.jl) | [![Build Status](https://travis-ci.org/JuliaPOMDP/AEMS.jl.svg?branch=master)](https://travis-ci.org/JuliaPOMDP/AEMS.jl) | [![Coverage Status](https://coveralls.io/repos/JuliaPOMDP/AEMS.jl/badge.svg)](https://coveralls.io/r/JuliaPOMDP/AEMS.jl)  |
 
 #### Reinforcement Learning:
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,6 +32,7 @@ JuliaPOMDP are as follows:
 - [DESPOT](https://github.com/JuliaPOMDP/DESPOT.jl)
 - [MCVI](https://github.com/JuliaPOMDP/MCVI.jl)
 - [POMDPSolve](https://github.com/JuliaPOMDP/POMDPSolve.jl)
+- [AEMS](https://github.com/JuliaPOMDP/AEMS.jl)
 
 ### Support Tools:
 

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -28,7 +28,8 @@ const NATIVE_PACKAGES = Set{String}(
                          "ParticleFilters",
                          "TabularTDLearning",
                          "POMDPReinforce",
-                         "POMCPOW"
+                         "POMCPOW",
+                         "AEMS"
                         ])
 
 # Packages registered on METADATA


### PR DESCRIPTION
The AEMS solver is ready for a first release. There are some minor cosmetic issues and I may make small changes in the coming days but most of the major stuff is done.

@zsunberg can you please the add coverall stuff (by pressing the buttons on the AEMS readme)? It won't let me because I apparently am a second-class citizen in this group.

As I mention in the documentation for AEMS, I think we should have an `update(policy, a, o)` function or pass in the action+observation to the `action` function. With a tree based solver, having these allows you to save the tree and move the root of the tree. You could search the tree for beliefs matching the current belief in order to set the node, but that's messy and possibly grossly inefficient. Giving the observation to the planner (or passing it into `action`) would also allow you easily build a planner that only depends on the previous observation (which you might want as a baseline).