### PR TITLE
Add the local approximation value iteration solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Many packages use the POMDPs.jl interface, including MDP and POMDP solvers, supp
 |  **`Package`**   |  **`Build`** | **`Coverage`** |
 |-------------------|----------------------|------------------|
 | [Value Iteration](https://github.com/JuliaPOMDP/DiscreteValueIteration.jl) | [![Build Status](https://travis-ci.org/JuliaPOMDP/DiscreteValueIteration.jl.svg?branch=master)](https://travis-ci.org/JuliaPOMDP/DiscreteValueIteration.jl)  | [![Coverage Status](https://coveralls.io/repos/github/JuliaPOMDP/DiscreteValueIteration.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaPOMDP/DiscreteValueIteration.jl?branch=master) |
+| [Local Approximation Value Iteration](https://github.com/JuliaPOMDP/LocalApproximationValueIteration.jl) | [![Build Status](https://travis-ci.org/JuliaPOMDP/LocalApproximationValueIteration.jl.svg?branch=master)](https://travis-ci.org/JuliaPOMDP/LocalApproximationValueIteration.jl) | [![Coverage Status](https://coveralls.io/repos/github/JuliaPOMDP/LocalApproximationValueIteration.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaPOMDP/LocalApproximationValueIteration.jl?branch=master)
 | [Monte Carlo Tree Search](https://github.com/JuliaPOMDP/MCTS.jl) | [![Build Status](https://travis-ci.org/JuliaPOMDP/MCTS.jl.svg?branch=master)](https://travis-ci.org/JuliaPOMDP/MCTS.jl) | [![Coverage Status](https://coveralls.io/repos/github/JuliaPOMDP/MCTS.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaPOMDP/MCTS.jl?branch=master) |
 
 #### POMDP solvers:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -21,6 +21,7 @@ JuliaPOMDP are as follows:
 ### MDP solvers:
 
 - [Value Iteration](https://github.com/JuliaPOMDP/DiscreteValueIteration.jl)
+- [Local Approximation Value Iteration](https://github.com/JuliaPOMDP/LocalApproximationValueIteration.jl)
 - [Monte Carlo Tree Search](https://github.com/JuliaPOMDP/MCTS.jl)
 
 ### POMDP solvers:

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -29,7 +29,8 @@ const NATIVE_PACKAGES = Set{String}(
                          "TabularTDLearning",
                          "POMDPReinforce",
                          "POMCPOW",
-                         "AEMS"
+                         "AEMS",
+                         "LocalApproximationValueIteration"
                         ])
 
 # Packages registered on METADATA


### PR DESCRIPTION
The [LocalApproximationValueIteration](https://github.com/JuliaPOMDP/LocalApproximationValueIteration.jl) solver has been added to `src/constants.jl` and updated in the README and docs.