### PR TITLE
QuickPOMDPs as Quick Start Example

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,7 +15,7 @@ makedocs(
             "concepts.md"
            ],
 
-        "Defining POMDP Models" => [
+        "Defining (PO)MDP Models" => [
             "def_pomdp.md",
             "explicit.md",
             "generative.md",

--- a/docs/src/def_pomdp.md
+++ b/docs/src/def_pomdp.md
@@ -1,7 +1,11 @@
-# [Defining POMDPs](@id defining_pomdps)
+# [Defining POMDPs and MDPs](@id defining_pomdps)
 
 The expressive nature of POMDPs.jl gives problem writers the flexibility to write their problem in many forms.
 Custom POMDP problems are defined by implementing the functions specified by the POMDPs API.
+
+!!! note
+
+    The main generative and explicit interfaces use an object-oriented programming paradigm and require familiarity with Julia. If you are defining a small to medium sized discrete problem, [QuickPOMDPs](https://github.com/JuliaPOMDP/QuickPOMDPs.jl) may be easier to use, and requires less Julia knowledge and no object-oriented programming.
 
 ## Types of problem definitions
 

--- a/docs/src/explicit.md
+++ b/docs/src/explicit.md
@@ -1,4 +1,4 @@
-# [Explicit POMDP Interface](@id explicit_doc)
+# [Explicit (PO)MDP Interface](@id explicit_doc)
 
 When using the explicit interface, the transition and observation probabilities must be explicitly defined. This section gives examples of two ways to define a discrete POMDP that is widely used in the literature.
 Note that there is no requirement that a problem defined using the explicit interface be discrete; it is equally easy to define a continuous problem using the explicit interface.

--- a/docs/src/generative.md
+++ b/docs/src/generative.md
@@ -1,4 +1,4 @@
-# [Generative POMDP Interface](@id generative_doc)
+# [Generative (PO)MDP Interface](@id generative_doc)
 
 ## Description
 
@@ -15,7 +15,7 @@ generate_sor(pomdp, s, a, rng) -> (s, o, r)
 initialstate(pomdp, rng) -> s
 ```
 
-Each `generate_` function is a single step simulator that returns a new state, observation, reward, or a combination given the current state and action (and `sp` in some cases). [`rng` is a random number generator such as `Base.GLOBAL_RNG` or another `MersenneTwister` that is passed as an argument and should be used to generate all random numbers within the function to ensure that all simulations are exactly repeatable.](http://docs.julialang.org/en/release-0.5/stdlib/numbers/#random-numbers)
+Each `generate_` function is a single step simulator that returns a new state, observation, reward, or a combination given the current state and action (and `sp` in some cases). [`rng` is a random number generator such as `Base.GLOBAL_RNG` or another `MersenneTwister` that is passed as an argument and should be used to generate all random numbers within the function to ensure that all simulations are exactly repeatable.](https://docs.julialang.org/en/v1/stdlib/Random/#Random-Numbers-1)
 
 The functions that do not deal with observations may be defined for `MDP`s as well as `POMDP`s.
 


### PR DESCRIPTION
I changed the quick start example in the README to use [QuickPOMDPs](https://github.com/JuliaPOMDP/QuickPOMDPs.jl) (see below).

### Pros
- shows a POMDP actually being defined instead of importing one from POMDPModels

### Cons
- might lead users to believe that this package can only express small discrete explicit problems and will be inefficient
- not typical of what a research problem implementation would look like

I think the pros outweigh the cons for this - **does anyone else have an opinion?**

from README.md:
```julia
using POMDPs, QuickPOMDPs, POMDPSimulators, QMDP

S = [:left, :right]
A = [:left, :right, :listen]
O = [:left, :right]
γ = 0.95

function T(s, a, sp)
    if a == :listen
        return s == sp
    else # a door is opened
        return 0.5 #reset
    end
end

function Z(a, sp, o)
    if a == :listen
        if o == sp
            return 0.85
        else
            return 0.15
        end
    else
        return 0.5
    end
end

function R(s, a)
    if a == :listen  
        return -1.0
    elseif s == a # the tiger was found
        return -100.0
    else # the tiger was escaped
        return 10.0
    end
end

m = DiscreteExplicitPOMDP(S,A,O,T,Z,R,γ)

solver = QMDPSolver()
policy = solve(solver, m)

rsum = 0.0
for (s,b,a,o,r) in stepthrough(m, policy, "s,b,a,o,r", max_steps=10)
    println("s: $s, b: $([pdf(b,s) for s in S]), a: $a, o: $o")
    global rsum += r
end
println("Undiscounted reward was $rsum.")
```
