### PR TITLE
using POMDPs in the example

### DIFF
--- a/docs/src/get_started.md
+++ b/docs/src/get_started.md
@@ -7,7 +7,7 @@ Here is a short piece of code that solves the Tiger POMDP using QMDP, and evalua
 have the QMDP, POMDPModels, and POMDPToolbox modules installed.
 
 ```julia
-using QMDP, POMDPModels, POMDPSimulators
+using POMDPs, QMDP, POMDPModels, POMDPSimulators
 
 # initialize problem and solver
 pomdp = TigerPOMDP() # from POMDPModels


### PR DESCRIPTION
Unless we do a `using POMDPs`, the call to updater() returns:
```
julia> belief_updater = updater(policy)
ERROR: UndefVarError: updater not defined
Stacktrace:
 [1] top-level scope at none:0
```