### PR TITLE
No registry instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,12 @@ There are [several ways to define and interact with (PO)MDPs](http://juliapomdp.
 For help, please post to the [Google group](https://groups.google.com/forum/#!forum/pomdps-users), or on [gitter](https://gitter.im/JuliaPOMDP). We welcome contributions from anyone! See [CONTRIBUTING.md](/CONTRIBUTING.md) for information about contributing. Check [releases](https://github.com/JuliaPOMDP/POMDPs.jl/releases) for information on changes. POMDPs.jl and all packages in the JuliaPOMDP project are fully supported on Linux and OS X. Windows is supported for all native solvers\*, and most non-native solvers should work, but may require additional configuration.
 
 ## Installation
-To install POMDPs.jl, run the following in the Julia REPL: 
+In the Julia REPL, run: 
 ```julia
 using Pkg; pkg"add POMDPs"
 ```
+
+Some auxiliary packages and older versions of solvers may be found in the JuliaPOMDP registry. To install this registry, see the [installation instructions](https://juliapomdp.github.io/POMDPs.jl/stable/install/).
 
 To install supported JuliaPOMDP packages including various solvers, first add the JuliaPOMDP registry:
 ```julia

--- a/README.md
+++ b/README.md
@@ -24,23 +24,13 @@ There are [several ways to define and interact with (PO)MDPs](http://juliapomdp.
 For help, please post to the [Google group](https://groups.google.com/forum/#!forum/pomdps-users), or on [gitter](https://gitter.im/JuliaPOMDP). We welcome contributions from anyone! See [CONTRIBUTING.md](/CONTRIBUTING.md) for information about contributing. Check [releases](https://github.com/JuliaPOMDP/POMDPs.jl/releases) for information on changes. POMDPs.jl and all packages in the JuliaPOMDP project are fully supported on Linux and OS X. Windows is supported for all native solvers\*, and most non-native solvers should work, but may require additional configuration.
 
 ## Installation
-In the Julia REPL, run: 
+
+POMDPs.jl and associated solver packages can be installed using [Julia's package manager](https://docs.julialang.org/en/v1/stdlib/Pkg/). For example, to install POMDPs.jl and the QMDP solver package, type the following in the Julia REPL:
 ```julia
-using Pkg; pkg"add POMDPs"
+using Pkg; Pkg.add("POMDPs"); Pkg.add("QMDP")
 ```
 
 Some auxiliary packages and older versions of solvers may be found in the JuliaPOMDP registry. To install this registry, see the [installation instructions](https://juliapomdp.github.io/POMDPs.jl/stable/install/).
-
-To install supported JuliaPOMDP packages including various solvers, first add the JuliaPOMDP registry:
-```julia
-using Pkg; pkg"registry add https://github.com/JuliaPOMDP/Registry"
-```
-Note: to use this registry, [JuliaPro](https://juliacomputing.com/products/juliapro) users must also run `edit(normpath(Sys.BINDIR,"..","etc","julia","startup.jl"))`, comment out the line `ENV["DISABLE_FALLBACK"] = "true"`, save the file, and restart JuliaPro as described in [this issue](https://github.com/JuliaPOMDP/POMDPs.jl/issues/249).
-
-You can then list packages with `POMDPs.available()` and install a solver (say `SARSOP.jl`) with
-```julia
-using Pkg; pkg"add SARSOP"
-```
 
 ## Quick Start
 

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -7,18 +7,9 @@ import Pkg
 Pkg.add("POMDPs") # installs the POMDPs.jl package
 ```
 
-Once you have POMDPs.jl installed, you can install any package that is part of the JuliaPOMDP community by running:
+Some auxiliary packages and older versions of solvers may be found in the JuliaPOMDP registry. To install this registry, run:
 ```julia
-using POMDPs, Pkg
-POMDPs.add_registry()
-Pkg.add("SARSOP") # installs the SARSOP solver
+using Pkg; pkg"registry add https://github.com/JuliaPOMDP/Registry"
 ```
 
-The code above will download and install all dependencies automatically. All JuliaPOMDP packages have been tested on
-Linux and OS X, and most have been tested on Windows.
-
-To get a list of all the available packages run:
-```julia
-POMDPs.available() # prints a list of all the available packages that can be installed with POMDPs.add
-```
-
+Note: to use this registry, [JuliaPro](https://juliacomputing.com/products/juliapro) users must also run `edit(normpath(Sys.BINDIR,"..","etc","julia","startup.jl"))`, comment out the line `ENV["DISABLE_FALLBACK"] = "true"`, save the file, and restart JuliaPro as described in [this issue](https://github.com/JuliaPOMDP/POMDPs.jl/issues/249).

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -112,6 +112,6 @@ function read_registry(regfile)
 end
 
 function add_registry(;kwargs...)
-    Base.depwarn("""POMDPs.add_registry() is deprecated. Use Pkg.pkg"registry add https://github.com/JuliaPOMDP/Registry" instead.""", :add_registry)
+    Base.depwarn("""POMDPs.add_registry() is deprecated. The JuliaPOMDP Registry is no longer needed to download most solvers. If the registry is needed, use Pkg.pkg"registry add https://github.com/JuliaPOMDP/Registry" instead.""", :add_registry)
     Pkg.pkg"registry add https://github.com/JuliaPOMDP/Registry"
 end


### PR DESCRIPTION
Once all the solvers are moved (#318), we should merge this to get rid of the registry instructions in the README