### PR TITLE
Fix for underlying MDP not preserving state-dependent action space

### DIFF
--- a/lib/POMDPTools/src/ModelTools/underlying_mdp.jl
+++ b/lib/POMDPTools/src/ModelTools/underlying_mdp.jl
@@ -22,6 +22,7 @@ POMDPs.transition(mdp::UnderlyingMDP{P, S, A}, s::S, a::A) where {P,S,A}= transi
 POMDPs.initialstate(m::UnderlyingMDP) = initialstate(m.pomdp)
 POMDPs.states(mdp::UnderlyingMDP) = states(mdp.pomdp)
 POMDPs.actions(mdp::UnderlyingMDP) = actions(mdp.pomdp)
+POMDPs.actions(mdp::UnderlyingMDP{P, S, A}, s::S) where {P,S,A} = actions(mdp.pomdp, s)
 POMDPs.reward(mdp::UnderlyingMDP{P, S, A}, s::S, a::A) where {P,S,A} = reward(mdp.pomdp, s, a)
 POMDPs.reward(mdp::UnderlyingMDP{P, S, A}, s::S, a::A, sp::S) where {P,S,A} = reward(mdp.pomdp, s, a, sp)
 POMDPs.isterminal(mdp ::UnderlyingMDP{P, S, A}, s::S) where {P,S,A} = isterminal(mdp.pomdp, s)

--- a/lib/POMDPTools/test/model_tools/test_underlying_mdp.jl
+++ b/lib/POMDPTools/test/model_tools/test_underlying_mdp.jl
@@ -25,4 +25,8 @@ let
     # test mdp passthrough
     m = SimpleGridWorld()
     @test UnderlyingMDP(m) === m
+
+    struct Issue429POMDP <: POMDP{Int, Int, Int} end
+    POMDPs.actions(m::Issue429POMDP, s) = [1,2]
+    @test actions(UnderlyingMDP(Issue429POMDP()), 1) == [1,2]
 end


### PR DESCRIPTION
Fixes JuliaPOMDP/POMDPs.jl#429 as proposed in the issue.