### PR TITLE
`FullyObservablePOMDP` `obsindex` bugfix

### DIFF
--- a/lib/POMDPTools/src/ModelTools/fully_observable_pomdp.jl
+++ b/lib/POMDPTools/src/ModelTools/fully_observable_pomdp.jl
@@ -14,18 +14,12 @@ end
 mdptype(::Type{FullyObservablePOMDP{M,S,A}}) where {M,S,A} = M
 
 POMDPs.observations(pomdp::FullyObservablePOMDP) = states(pomdp.mdp)
-POMDPs.obsindex(pomdp::FullyObservablePOMDP{S, A}, o::S) where {S, A} = stateindex(pomdp.mdp, o)
+POMDPs.obsindex(pomdp::FullyObservablePOMDP, o) = stateindex(pomdp.mdp, o)
 
 POMDPs.convert_o(T::Type{V}, o, pomdp::FullyObservablePOMDP) where {V<:AbstractArray} = convert_s(T, o, pomdp.mdp)
 POMDPs.convert_o(T::Type{S}, vec::V, pomdp::FullyObservablePOMDP) where {S,V<:AbstractArray} = convert_s(T, vec, pomdp.mdp)
 
-function POMDPs.observation(pomdp::FullyObservablePOMDP, a, sp)
-    return Deterministic(sp)
-end
-
-function POMDPs.observation(pomdp::FullyObservablePOMDP, s, a, sp)
-    return Deterministic(sp)
-end
+POMDPs.observation(::FullyObservablePOMDP, a, sp) = Deterministic(sp)
 
 # inherit other function from the MDP type
 

--- a/lib/POMDPTools/test/model_tools/test_fully_observable_pomdp.jl
+++ b/lib/POMDPTools/test/model_tools/test_fully_observable_pomdp.jl
@@ -12,6 +12,7 @@ let
     s_po = rand(MersenneTwister(1), initialstate(pomdp))
     s_mdp = rand(MersenneTwister(1), initialstate(mdp))
     @test s_po == s_mdp
+    @test stateindex(mdp, s_mdp) == stateindex(pomdp, s_po) == obsindex(pomdp, s_po)
 
     solver = ValueIterationSolver(max_iterations = 100)
     @test_skip begin


### PR DESCRIPTION
Removed unnecessary parametric typing for `obsindex` + added test.

Also removed redundant observation function for `FullyObservablePOMDP` that is already covered in POMDPs.jl.

https://github.com/JuliaPOMDP/POMDPs.jl/blob/cc15fe957d97ec1c41a2415843eebe8157670ab1/lib/POMDPTools/src/ModelTools/fully_observable_pomdp.jl#L22-L28

(Lines 26-28 redundant)

https://github.com/JuliaPOMDP/POMDPs.jl/blob/cc15fe957d97ec1c41a2415843eebe8157670ab1/src/pomdp.jl#L64