### PR TITLE
Update def_updater.md

### DIFF
--- a/docs/src/def_updater.md
+++ b/docs/src/def_updater.md
@@ -40,7 +40,7 @@ import POMDPs
 
 struct HistoryUpdater <: POMDPs.Updater end
 
-initialize_belief(up::HistoryUpdater, d) = Any[d]
+POMDPs.initialize_belief(up::HistoryUpdater, d) = Any[d]
 
 function POMDPs.update(up::HistoryUpdater, b, a, o)
     bp = copy(b)


### PR DESCRIPTION
Missing package name.

It makes an error as follows.
 
ERROR: MethodError: no method matching copy(::BoolDistribution)