### PR TITLE
Use Random.default_rng()

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Distributions = "0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
 Graphs = "1"
 NamedTupleTools = "0.10, 0.11, 0.12, 0.13, 0.14"
 POMDPLinter = "0.1"
-julia = "1"
+julia = "1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/lib/POMDPTools/Project.toml
+++ b/lib/POMDPTools/Project.toml
@@ -37,7 +37,7 @@ StableRNGs = "1"
 StatsBase = "0.30, 0.31, 0.32, 0.33, 0.34"
 Tricks = "0.1"
 UnicodePlots = "1, 2, 3"
-julia = "1"
+julia = "1.3"
 
 [extras]
 DiscreteValueIteration = "4b033969-44f6-5439-a48b-c11fa3648068"

--- a/lib/POMDPTools/src/Policies/exploration_policies.jl
+++ b/lib/POMDPTools/src/Policies/exploration_policies.jl
@@ -43,7 +43,7 @@ The evolution of epsilon can be controlled using a schedule. This feature is use
 
 # Constructor:
 
-`EpsGreedyPolicy(problem::Union{MDP, POMDP}, eps::Union{Function, Float64}; rng=Random.GLOBAL_RNG, schedule=ConstantSchedule)`
+`EpsGreedyPolicy(problem::Union{MDP, POMDP}, eps::Union{Function, Float64}; rng=Random.default_rng(), schedule=ConstantSchedule)`
 
 If a function is passed for `eps`, `eps(k)` is called to compute the value of epsilon when calling `action(exploration_policy, on_policy, k, s)`.
 
@@ -61,11 +61,11 @@ struct EpsGreedyPolicy{T<:Function, R<:AbstractRNG, M<:Union{MDP,POMDP}} <: Expl
 end
 
 function EpsGreedyPolicy(problem::Union{MDP,POMDP}, eps::Function; 
-                         rng::AbstractRNG=Random.GLOBAL_RNG)
+                         rng::AbstractRNG=Random.default_rng())
     return EpsGreedyPolicy(eps, rng, problem)
 end
 function EpsGreedyPolicy(problem::Union{MDP,POMDP}, eps::Real; 
-                         rng::AbstractRNG=Random.GLOBAL_RNG)
+                         rng::AbstractRNG=Random.default_rng())
     return EpsGreedyPolicy(x->eps, rng, problem)
 end
 
@@ -90,7 +90,7 @@ A temperature parameter or function can be used to make the resulting distributi
 
 # Constructor
 
-`SoftmaxPolicy(problem, temperature::Union{Function, Float64}; rng=Random.GLOBAL_RNG)`
+`SoftmaxPolicy(problem, temperature::Union{Function, Float64}; rng=Random.default_rng())`
 
 If a function is passed for `temperature`, `temperature(k)` is called to compute the value of the temperature when calling `action(exploration_policy, on_policy, k, s)`
 
@@ -108,11 +108,11 @@ struct SoftmaxPolicy{T<:Function, R<:AbstractRNG, A} <: ExplorationPolicy
 end
 
 function SoftmaxPolicy(problem, temperature::Function; 
-                       rng::AbstractRNG=Random.GLOBAL_RNG)
+                       rng::AbstractRNG=Random.default_rng())
     return SoftmaxPolicy(temperature, rng, actions(problem))
 end
 function SoftmaxPolicy(problem, temperature::Real; 
-                       rng::AbstractRNG=Random.GLOBAL_RNG)
+                       rng::AbstractRNG=Random.default_rng())
     return SoftmaxPolicy(x->temperature, rng, actions(problem))
 end
 

--- a/lib/POMDPTools/src/Policies/random.jl
+++ b/lib/POMDPTools/src/Policies/random.jl
@@ -7,7 +7,7 @@ a generic policy that uses the actions function to create a list of actions and 
 Constructor:
 
     `RandomPolicy(problem::Union{POMDP,MDP};
-             rng=Random.GLOBAL_RNG,
+             rng=Random.default_rng(),
              updater=NothingUpdater())`
 
 # Fields 
@@ -22,7 +22,7 @@ mutable struct RandomPolicy{RNG<:AbstractRNG, P<:Union{POMDP,MDP}, U<:Updater} <
 end
 # The constructor below should be used to create the policy so that the action space is initialized correctly
 RandomPolicy(problem::Union{POMDP,MDP};
-             rng=Random.GLOBAL_RNG,
+             rng=Random.default_rng(),
              updater=NothingUpdater()) = RandomPolicy(rng, problem, updater)
 
 ## policy execution ##
@@ -43,5 +43,5 @@ solver that produces a random policy
 mutable struct RandomSolver <: Solver
     rng::AbstractRNG
 end
-RandomSolver(;rng=Random.GLOBAL_RNG) = RandomSolver(rng)
+RandomSolver(;rng=Random.default_rng()) = RandomSolver(rng)
 solve(solver::RandomSolver, problem::Union{POMDP,MDP}) = RandomPolicy(solver.rng, problem, NothingUpdater())

--- a/lib/POMDPTools/src/Policies/stochastic.jl
+++ b/lib/POMDPTools/src/Policies/stochastic.jl
@@ -8,7 +8,7 @@ Represents a stochastic policy. Action are sampled from an arbitrary distributio
 
 Constructor:
 
-    `StochasticPolicy(distribution; rng=Random.GLOBAL_RNG)`
+    `StochasticPolicy(distribution; rng=Random.default_rng())`
 
 # Fields 
 - `distribution::D`
@@ -19,7 +19,7 @@ mutable struct StochasticPolicy{D, RNG <: AbstractRNG} <: Policy
     rng::RNG
 end
 # The constructor below should be used to create the policy so that the action space is initialized correctly
-StochasticPolicy(distribution; rng=Random.GLOBAL_RNG) = StochasticPolicy(distribution, rng)
+StochasticPolicy(distribution; rng=Random.default_rng()) = StochasticPolicy(distribution, rng)
 
 ## policy execution ##
 function action(policy::StochasticPolicy, s)
@@ -30,7 +30,7 @@ end
 updater(policy::StochasticPolicy) = NothingUpdater() # since the stochastic policy does not depend on the belief
 
 # Samples actions uniformly
-UniformRandomPolicy(problem, rng=Random.GLOBAL_RNG) = StochasticPolicy(actions(problem), rng)
+UniformRandomPolicy(problem, rng=Random.default_rng()) = StochasticPolicy(actions(problem), rng)
 
 """
     CategoricalTabularPolicy
@@ -39,7 +39,7 @@ represents a stochastic policy sampling an action from a categorical distributio
 
 constructor:
 
-`CategoricalTabularPolicy(mdp::Union{POMDP,MDP}; rng=Random.GLOBAL_RNG)`
+`CategoricalTabularPolicy(mdp::Union{POMDP,MDP}; rng=Random.default_rng())`
 
 # Fields
 - `stochastic::StochasticPolicy`
@@ -49,7 +49,7 @@ mutable struct CategoricalTabularPolicy <: Policy
     stochastic::StochasticPolicy
     value::ValuePolicy
 end
-function CategoricalTabularPolicy(mdp::Union{POMDP,MDP}; rng=Random.GLOBAL_RNG)
+function CategoricalTabularPolicy(mdp::Union{POMDP,MDP}; rng=Random.default_rng())
     CategoricalTabularPolicy(StochasticPolicy(Weights(zeros(length(actions((mdp))))), rng), ValuePolicy(mdp))
 end
 

--- a/lib/POMDPTools/src/Simulators/display.jl
+++ b/lib/POMDPTools/src/Simulators/display.jl
@@ -40,7 +40,7 @@ function DisplaySimulator(;display=nothing,
                            extra_final=true,
                            max_steps=nothing,
                            spec=CompleteSpec(),
-                           rng=Random.GLOBAL_RNG
+                           rng=Random.default_rng()
                          )
     stepsim = StepSimulator(rng, max_steps, spec)
     return DisplaySimulator(display,

--- a/lib/POMDPTools/src/Simulators/history_recorder.jl
+++ b/lib/POMDPTools/src/Simulators/history_recorder.jl
@@ -34,7 +34,7 @@ mutable struct HistoryRecorder <: Simulator
 end
 
 # This is the only stable constructor
-function HistoryRecorder(;rng=Random.GLOBAL_RNG,
+function HistoryRecorder(;rng=Random.default_rng(),
                           eps=nothing,
                           max_steps=nothing,
                           capture_exception=false,

--- a/lib/POMDPTools/src/Simulators/parallel.jl
+++ b/lib/POMDPTools/src/Simulators/parallel.jl
@@ -7,7 +7,7 @@ Create a Sim object that contains everything needed to run and record a single s
 A vector of `Sim` objects can be executed with [`run`](@ref) or [`run_parallel`](@ref).
 
 ## Keyword Arguments
-- `rng::AbstractRNG=Random.GLOBAL_RNG`
+- `rng::AbstractRNG=Random.default_rng()`
 - `max_steps::Int=typemax(Int)`
 - `simulator::Simulator=HistoryRecorder(rng=rng, max_steps=max_steps)`
 - `metadata::NamedTuple a named tuple (or dictionary) of metadata for the sim that will be recorded, e.g. `(solver_iterations=500,)`.
@@ -47,7 +47,7 @@ function Sim(pomdp::POMDP,
              up=updater(policy),
              initial_belief=initialstate(pomdp),
              initialstate=nothing;
-             rng::AbstractRNG=Random.GLOBAL_RNG,
+             rng::AbstractRNG=Random.default_rng(),
              max_steps::Int=typemax(Int),
              simulator::Simulator=HistoryRecorder(rng=rng, max_steps=max_steps),
              metadata = NamedTuple()
@@ -70,7 +70,7 @@ Create a `Sim` object that represents a MDP simulation.
 function Sim(mdp::MDP,
              policy::Policy,
              initialstate=nothing;
-             rng::AbstractRNG=Random.GLOBAL_RNG,
+             rng::AbstractRNG=Random.default_rng(),
              max_steps::Int=typemax(Int),
              simulator::Simulator=HistoryRecorder(rng=rng, max_steps=max_steps),
              metadata = NamedTuple()

--- a/lib/POMDPTools/src/Simulators/rollout.jl
+++ b/lib/POMDPTools/src/Simulators/rollout.jl
@@ -13,7 +13,7 @@ The simulation will be terminated when either
 3) max_steps have been executed
 
 # Keyword arguments:
-- rng::AbstractRNG (default: Random.GLOBAL_RNG) - A random number generator to use. 
+- rng::AbstractRNG (default: Random.default_rng()) - A random number generator to use. 
 - eps::Float64 (default: 0.0) - A small number; if γᵗ where γ is the discount factor and t is the time step becomes smaller than this, the simulation will be terminated.
 - max_steps::Int (default: typemax(Int)) - The maximum number of steps to simulate.
 
@@ -32,7 +32,7 @@ struct RolloutSimulator{RNG<:AbstractRNG} <: Simulator
     eps::Float64
 end
 
-function RolloutSimulator(;rng=Random.GLOBAL_RNG,
+function RolloutSimulator(;rng=Random.default_rng(),
     eps=0.0,
     max_steps=typemax(Int))
     return RolloutSimulator(rng, max_steps, eps)

--- a/lib/POMDPTools/src/Simulators/sim.jl
+++ b/lib/POMDPTools/src/Simulators/sim.jl
@@ -126,8 +126,8 @@ function default_init_obs(p::POMDP, s)
 end
 
 @generated function default_init_state(p::Union{MDP,POMDP})
-    if implemented(initialstate, Tuple{p, typeof(Random.GLOBAL_RNG)})
-        return :(rand(Random.GLOBAL_RNG, initialstate(p)))
+    if implemented(initialstate, Tuple{p, typeof(Random.default_rng())})
+        return :(rand(Random.default_rng(), initialstate(p)))
     else
         return quote
             error("""

--- a/lib/POMDPTools/src/Simulators/stepthrough.jl
+++ b/lib/POMDPTools/src/Simulators/stepthrough.jl
@@ -6,7 +6,7 @@ struct StepSimulator <: Simulator
     max_steps::Union{Nothing,Any}
     spec
 end
-function StepSimulator(spec; rng=Random.GLOBAL_RNG, max_steps=nothing)
+function StepSimulator(spec; rng=Random.default_rng(), max_steps=nothing)
     return StepSimulator(rng, max_steps, spec)
 end
 

--- a/lib/POMDPTools/test/distributions/test_sparse_cat.jl
+++ b/lib/POMDPTools/test/distributions/test_sparse_cat.jl
@@ -7,7 +7,7 @@ let
     @test mode(d) == :b
     @test Random.gentype(d) == Symbol
     @test Random.gentype(typeof(d)) == Symbol
-    @inferred rand(Random.GLOBAL_RNG, d)
+    @inferred rand(Random.default_rng(), d)
 
     dt = SparseCat((:a, :b, :d), (0.4, 0.5, 0.1))
     c = collect(weighted_iterator(dt))
@@ -17,7 +17,7 @@ let
     @test mode(dt) == :b
     @test Random.gentype(dt) == Symbol
     @test Random.gentype(typeof(dt)) == Symbol
-    @inferred rand(Random.GLOBAL_RNG, dt)
+    @inferred rand(Random.default_rng(), dt)
     
     # rand(::SparseCat)
     samples = Symbol[]
@@ -49,7 +49,7 @@ let
     @test isapprox(count(samples.==:c)/N, pdf(d,:c), atol=0.005)
     @test isapprox(count(samples.==:d)/N, pdf(d,:d), atol=0.005)
 
-    @test_throws ErrorException rand(Random.GLOBAL_RNG, SparseCat([1], [0.0]))
+    @test_throws ErrorException rand(Random.default_rng(), SparseCat([1], [0.0]))
 
     @test sprint((io,d)->show(io,MIME("text/plain"),d), d) == sprint((io,d)->showdistribution(io,d,title="SparseCat distribution"), d)
 

--- a/lib/POMDPTools/test/model_tools/test_generative_belief_mdp.jl
+++ b/lib/POMDPTools/test/model_tools/test_generative_belief_mdp.jl
@@ -3,5 +3,5 @@ let
     up = updater(pomdp)
 
     bmdp = GenerativeBeliefMDP(pomdp, up)
-    b = initialstate(bmdp, Random.GLOBAL_RNG)
+    b = initialstate(bmdp, Random.default_rng())
 end

--- a/lib/POMDPTools/test/model_tools/test_info.jl
+++ b/lib/POMDPTools/test/model_tools/test_info.jl
@@ -7,7 +7,7 @@ let
         problem::P
     end
     InfoTestRandomPolicy(problem::Union{POMDP,MDP};
-                rng=Random.GLOBAL_RNG) = InfoTestRandomPolicy(rng, problem)
+                rng=Random.default_rng()) = InfoTestRandomPolicy(rng, problem)
 
     function POMDPs.action(policy::InfoTestRandomPolicy, s)
         return rand(policy.rng, actions(policy.problem, s))
@@ -17,7 +17,7 @@ let
         rng::AbstractRNG
     end
 
-    InfoTestRandomSolver(;rng=Base.GLOBAL_RNG) = InfoTestRandomSolver(rng)
+    InfoTestRandomSolver(;rng=Base.default_rng()) = InfoTestRandomSolver(rng)
     POMDPs.solve(solver::InfoTestRandomSolver, problem::P) where {P<:Union{POMDP,MDP}} = InfoTestRandomPolicy(solver.rng, problem)
 
     let

--- a/src/generative.jl
+++ b/src/generative.jl
@@ -62,6 +62,6 @@ Let `m` be an `MDP` or `POMDP`, `s` be a state of `m`, `a` be an action of `m`, 
 macro gen(symbols...)
     quote
         # this should be an anonymous function, but there is a bug (https://github.com/JuliaLang/julia/issues/36272)
-        f(m, s, a, rng=Random.GLOBAL_RNG) = genout(DDNOut($(symbols...)), m, s, a, rng)
+        f(m, s, a, rng=Random.default_rng()) = genout(DDNOut($(symbols...)), m, s, a, rng)
     end
 end

--- a/test/test_generative.jl
+++ b/test/test_generative.jl
@@ -10,25 +10,25 @@ struct W <: POMDP{Int, Bool, Int} end
 @test_throws MethodError initialstate(W())
 @test_throws MethodError initialobs(W(), 1)
 try
-    @gen(:sp)(W(), 1, true, Random.GLOBAL_RNG)
+    @gen(:sp)(W(), 1, true, Random.default_rng())
 catch ex
     str = sprint(showerror, ex)
     @test occursin("transition", str)
 end
-@test_throws MethodError @gen(:sp,:r)(W(), 1, true, Random.GLOBAL_RNG)
+@test_throws MethodError @gen(:sp,:r)(W(), 1, true, Random.default_rng())
 
-@test_throws MethodError @gen(:sp,:o)(W(), 1, true, Random.GLOBAL_RNG)
-@test_throws MethodError @gen(:sp,:o,:r)(W(), 1, true, Random.GLOBAL_RNG)
+@test_throws MethodError @gen(:sp,:o)(W(), 1, true, Random.default_rng())
+@test_throws MethodError @gen(:sp,:o,:r)(W(), 1, true, Random.default_rng())
 POMDPs.gen(::W, ::Int, ::Bool, ::AbstractRNG) = nothing
-@test_throws AssertionError @gen(:sp)(W(), 1, true, Random.GLOBAL_RNG)
-@test_throws AssertionError @gen(:sp,:r)(W(), 1, true, Random.GLOBAL_RNG)
+@test_throws AssertionError @gen(:sp)(W(), 1, true, Random.default_rng())
+@test_throws AssertionError @gen(:sp,:r)(W(), 1, true, Random.default_rng())
 POMDPs.gen(::W, ::Int, ::Bool, ::AbstractRNG) = (useless=nothing,)
-@test_throws MethodError @gen(:sp,:r)(W(), 1, true, Random.GLOBAL_RNG)
+@test_throws MethodError @gen(:sp,:r)(W(), 1, true, Random.default_rng())
 
 transition(::W, s, a) = Deterministic(s)
-@test_throws MethodError @gen(:o)(W(), 1, true, Random.GLOBAL_RNG)
+@test_throws MethodError @gen(:o)(W(), 1, true, Random.default_rng())
 try
-    @gen(:o)(W(), 1, true, Random.GLOBAL_RNG)
+    @gen(:o)(W(), 1, true, Random.default_rng())
 catch ex
     str = sprint(showerror, ex)
     @test occursin("observation", str)
@@ -37,31 +37,31 @@ end
 struct B <: POMDP{Int, Bool, Bool} end
 
 transition(b::B, s::Int, a::Bool) = Deterministic(s+a)
-@test @inferred_except_1_0(@gen(:sp)(B(), 1, false, Random.GLOBAL_RNG)) == 1
+@test @inferred_except_1_0(@gen(:sp)(B(), 1, false, Random.default_rng())) == 1
 
-@test_throws MethodError @gen(:sp,:o,:r)(B(), 1, false, Random.GLOBAL_RNG)
+@test_throws MethodError @gen(:sp,:o,:r)(B(), 1, false, Random.default_rng())
 
 reward(b::B, s::Int, a::Bool, sp::Int) = -1.0
 observation(b::B, s::Int, a::Bool, sp::Int) = Deterministic(sp)
-@test @inferred_except_1_0(@gen(:sp,:r)(B(), 1, false, Random.GLOBAL_RNG)) == (1, -1.0)
+@test @inferred_except_1_0(@gen(:sp,:r)(B(), 1, false, Random.default_rng())) == (1, -1.0)
 
-@test @inferred_except_1_0(@gen(:sp,:o,:r)(B(), 1, true, Random.GLOBAL_RNG)) == (2, 2, -1.0)
+@test @inferred_except_1_0(@gen(:sp,:o,:r)(B(), 1, true, Random.default_rng())) == (2, 2, -1.0)
 
 mutable struct C <: POMDP{Nothing, Nothing, Nothing} end
 transition(c::C, s::Nothing, a::Nothing) = Deterministic(nothing)
 observation(c::C, s::Nothing, a::Nothing, sp::Nothing) = Deterministic(nothing)
 reward(c::C, s::Nothing, a::Nothing) = 0.0
-@test @inferred_except_1_0(@gen(:sp,:o,:r)(C(), nothing, nothing, Random.GLOBAL_RNG)) == (nothing, nothing, 0.0)
+@test @inferred_except_1_0(@gen(:sp,:o,:r)(C(), nothing, nothing, Random.default_rng())) == (nothing, nothing, 0.0)
 
 struct GD <: MDP{Int, Int} end
 POMDPs.transition(::GD, s, a) = Deterministic(s + a)
-@test @inferred_except_1_0(@gen(:sp)(GD(), 1, 1, Random.GLOBAL_RNG)) == 2
+@test @inferred_except_1_0(@gen(:sp)(GD(), 1, 1, Random.default_rng())) == 2
 POMDPs.reward(::GD, s, a) = s + a
-@test @inferred_except_1_0(@gen(:r)(GD(), 1, 1, Random.GLOBAL_RNG)) == 2
+@test @inferred_except_1_0(@gen(:r)(GD(), 1, 1, Random.default_rng())) == 2
 
 struct GE <: MDP{Int, Int} end
-@test_throws MethodError @gen(:sp)(GE(), 1, 1, Random.GLOBAL_RNG)
-@test_throws MethodError @gen(:sp,:r)(GE(), 1, 1, Random.GLOBAL_RNG)
+@test_throws MethodError @gen(:sp)(GE(), 1, 1, Random.default_rng())
+@test_throws MethodError @gen(:sp,:r)(GE(), 1, 1, Random.default_rng())
 POMDPs.gen(::GE, s, a, ::AbstractRNG) = (sp=s+a, r=s^2)
-@test @inferred_except_1_0(@gen(:sp)(GE(), 1, 1, Random.GLOBAL_RNG)) == 2
-@test @inferred_except_1_0(@gen(:sp, :r)(GE(), 1, 1, Random.GLOBAL_RNG)) == (2, 1)
+@test @inferred_except_1_0(@gen(:sp)(GE(), 1, 1, Random.default_rng())) == 2
+@test @inferred_except_1_0(@gen(:sp, :r)(GE(), 1, 1, Random.default_rng())) == (2, 1)


### PR DESCRIPTION
Related [issue](https://github.com/JuliaPOMDP/POMDPs.jl/issues/496)

Since the julia [documentation](https://docs.julialang.org/en/v1/stdlib/Random/#Generators-(creation-and-seeding)) noticed that "Across different versions of Julia, you should not expect the default RNG to be always the same", I add a compat for julia: `julia = "1.3"`

If it is wrong, please correct me. Thanks for your review.