### PR TITLE
WIP: Add `action(policy, s)` interface to exploration policies

### DIFF
--- a/lib/POMDPTools/src/Policies/Policies.jl
+++ b/lib/POMDPTools/src/Policies/Policies.jl
@@ -68,7 +68,8 @@ export LinearDecaySchedule,
        EpsGreedyPolicy,
        SoftmaxPolicy,
        ExplorationPolicy,
-       loginfo
+       loginfo,
+       update!
 
 include("exploration_policies.jl")
 

--- a/lib/POMDPTools/test/policies/test_exploration_policies.jl
+++ b/lib/POMDPTools/test/policies/test_exploration_policies.jl
@@ -7,18 +7,24 @@ a = first(actions(problem))
 @inferred action(policy, FunctionPolicy(s->a::Symbol), 1, GWPos(1,1))
 policy = EpsGreedyPolicy(problem, 0.0)
 @test action(policy, FunctionPolicy(s->a), 1, GWPos(1,1)) == a
+policy = EpsGreedyPolicy(problem, FunctionPolicy(s->a), 0.0)
+@test action(policy, GWPos(1,1)) == a
 
-# softmax 
+# softmax
 policy = SoftmaxPolicy(problem, 0.5)
 @test loginfo(policy, 1).temperature == 0.5
 on_policy = ValuePolicy(problem)
 @inferred action(policy, on_policy, 1, GWPos(1,1))
 
-# test linear schedule 
-policy = EpsGreedyPolicy(problem, LinearDecaySchedule(start=1.0, stop=0.0, steps=10))
-for i=1:11 
+# test linear schedule
+schedule = LinearDecaySchedule(start=1.0, stop=0.0, steps=10)
+policy = EpsGreedyPolicy(problem, FunctionPolicy(s->a), schedule)
+for i=1:11
     action(policy, FunctionPolicy(s->a), i, GWPos(1,1))
-    @test policy.eps(i) < 1.0 
+    @test policy.eps(i) < 1.0
     @test loginfo(policy, i).eps == policy.eps(i)
 end
 @test policy.eps(11) ≈ 0.0
+update!(policy, 11)
+@test policy.eps(policy.k) ≈ 0.0
+@test action(policy, FunctionPolicy(s->a), 11, GWPos(1,1)) == action(policy, GWPos(1,1))


### PR DESCRIPTION
To address https://github.com/JuliaPOMDP/POMDPs.jl/issues/497, I extended `EpsGreedyPolicy` by internal fields for the greedy policy and the iteration `k`. If this seems like a reasonable way to go, I can make similar changes to `SoftmaxPolicy` and edit doc strings. If not feel free to close this PR.

With this change both interfaces are supported:
`action(p::EpsGreedyPolicy, on_policy::Policy, k, s)`
`action(p::EpsGreedyPolicy, s)`