### PR TITLE
Remove latest observation from CommonRLEnv POMDP state

### DIFF
--- a/lib/POMDPTools/src/CommonRLIntegration/CommonRLIntegration.jl
+++ b/lib/POMDPTools/src/CommonRLIntegration/CommonRLIntegration.jl
@@ -10,14 +10,15 @@ using Tricks: static_hasmethod
 
 export
     MDPCommonRLEnv,
-    POMDPCommonRLEnv
-include("to_env.jl") 
+    POMDPCommonRLEnv,
+    POMDPsCommonRLEnv
+include("to_env.jl")
 
 export
     RLEnvMDP,
     RLEnvPOMDP,
     OpaqueRLEnvMDP,
     OpaqueRLEnvPOMDP
-include("from_env.jl") 
+include("from_env.jl")
 
 end

--- a/lib/POMDPTools/src/CommonRLIntegration/to_env.jl
+++ b/lib/POMDPTools/src/CommonRLIntegration/to_env.jl
@@ -88,7 +88,7 @@ RL.valid_actions(env::POMDPCommonRLEnv) = actions(env.m, env.s)
 RL.observations(env::POMDPCommonRLEnv{RLO}) where {RLO} = (convert_o(RLO, o, env.m) for o in observations(env.m)) # should really be some kind of lazy map that handles uncountably infinite spaces
 RL.provided(::typeof(RL.observations), ::Type{<:Tuple{POMDPCommonRLEnv{<:Any,<:Any,M,<:Any,<:Any}}}) where {M} = static_hasmethod(observations, Tuple{<:M})
 
-RL.@provide function RL.setstate!(env::POMDPCommonRLEnv{<:Any,<:Any,<:Any,S}, s) where {S}
+function RL.setstate!(env::POMDPCommonRLEnv{<:Any,<:Any,<:Any,S}, s) where {S}
     env.s = convert_s(S, s, env.m)
     env.o = rand(initialobs(env.m, env.s))
     return nothing

--- a/lib/POMDPTools/src/CommonRLIntegration/to_env.jl
+++ b/lib/POMDPTools/src/CommonRLIntegration/to_env.jl
@@ -97,5 +97,14 @@ end
 Base.convert(::Type{RL.AbstractEnv}, m::POMDP) = POMDPCommonRLEnv(m)
 Base.convert(::Type{RL.AbstractEnv}, m::MDP) = MDPCommonRLEnv(m)
 
+POMDPsCommonRLEnv(m::POMDP, s) = POMDPCommonRLEnv(m, s)
+POMDPsCommonRLEnv(m::MDP, s) = MDPCommonRLEnv(m, s)
+
 Base.convert(::Type{MDP}, env::MDPCommonRLEnv) = env.m
 Base.convert(::Type{POMDP}, env::POMDPCommonRLEnv) = env.m
+
+POMDPs.convert_s(::Type{Any}, s::S, problem::Union{MDP{S},POMDP{S}}) where {S} = s
+POMDPs.convert_s(::Type{S}, s, problem::Union{MDP{S},POMDP{S}}) where {S} = convert(S, s)
+
+POMDPs.convert_o(::Type{Any}, o::O, problem::POMDP{<:Any,<:Any,O}) where {O} = o
+POMDPs.convert_o(::Type{O}, o, problem::POMDP{<:Any,<:Any,O}) where {O} = convert(O, o)

--- a/lib/POMDPTools/test/common_rl_integration/test_common_rl.jl
+++ b/lib/POMDPTools/test/common_rl_integration/test_common_rl.jl
@@ -64,7 +64,7 @@ end
     @test RL.actions(env) == [-1, 1]
     @test RL.valid_actions(env) == [-1, 1]
     @test RL.observe(env) == [2]
-    @test RL.state(env) == (1,2)
+    @test RL.state(env) == [1]
     RL.setstate!(env, RL.state(env))
     @test RL.act!(env, 1) == 2
     @test !RL.terminated(env)
@@ -76,7 +76,7 @@ end
     @test RL.observe(env) == [4]
     @test RL.terminated(env)
 
-    RL.setstate!(env, (2,3))
+    RL.setstate!(env, [2])
     @test RL.observe(env) == [3]
 
     env2 = RL.clone(env)


### PR DESCRIPTION
I find it inconsistent that `state(::MDPCommonRLEnv)` returns the state (converted to type `RLO`) but `state(::POMDPCommonRLEnv)` returns a state-observation tuple, without converting anything. Since the observation is not really part of the state, I think it makes sense to not provide it as part of `state(::POMDPCommonRLEnv)`. Additionally, the state should also be optionally converted to another type, just like the observation.

This PR implements the proposed changes.