### PR TITLE
Replace @kwdef with Base.@kwdef to make the package compatible with older Julia versions

### DIFF
--- a/lib/POMDPTools/src/Policies/dict.jl
+++ b/lib/POMDPTools/src/Policies/dict.jl
@@ -8,7 +8,7 @@ A generic MDP policy that consists of a `Dict` storing Q-values for state-action
 - `default_value::Float64` the defalut value of `value_dict`.
 - `default_policy::Policy` the policy taken when no action has a value higher than `default_value`
 """
-@kwdef struct ValueDictPolicy{M<:MDP, T<:AbstractDict, P<:Policy} <: Policy
+Base.@kwdef struct ValueDictPolicy{M<:MDP, T<:AbstractDict, P<:Policy} <: Policy
     mdp::M
     value_dict::T          = Dict{Tuple{statetype(mdp), actiontype(mdp)}, Float64}()
     default_value::Float64 = -Inf


### PR DESCRIPTION
The current package doesn't work in Julia 1.8 (and maybe even prior versions) because the Base module was not used before @kwdef in the dict.jl file inside POMDPTools.jl 