### PR TITLE
ProgressMeter Deprecation Warning and nothing comparison

### DIFF
--- a/lib/POMDPTools/src/POMDPDistributions/sparse_cat.jl
+++ b/lib/POMDPTools/src/POMDPDistributions/sparse_cat.jl
@@ -83,7 +83,7 @@ function Base.iterate(d::SparseCat, dstate::Tuple)
     vstate, pstate = dstate
     vnext = iterate(d.vals, vstate)
     pnext = iterate(d.probs, pstate)
-    if vnext == nothing || pnext == nothing
+    if vnext === nothing || pnext === nothing
         return nothing 
     end
     val, vstate_next = vnext

--- a/lib/POMDPTools/src/Policies/utility_wrapper.jl
+++ b/lib/POMDPTools/src/Policies/utility_wrapper.jl
@@ -69,7 +69,7 @@ function PolicyWrapper(policy::Policy; payload=nothing)
 end
 
 function action(p::PolicyWrapper, s)
-    if p.payload == nothing
+    if p.payload === nothing
         return p.f(p.policy, s)
     else
         return p.f(p.policy, p.payload, s)

--- a/lib/POMDPTools/src/Simulators/history_recorder.jl
+++ b/lib/POMDPTools/src/Simulators/history_recorder.jl
@@ -92,7 +92,7 @@ function simulate(sim::HistoryRecorder,
         if (sim.max_steps === nothing) && (sim.eps === nothing)
             error("If show_progress=true in a HistoryRecorder, you must also specify max_steps or eps.")
         end
-        prog = Progress(max_steps, "Simulating..." )
+        prog = Progress(max_steps; desc="Simulating..." )
     else
         prog = nothing
     end
@@ -150,7 +150,7 @@ function simulate(sim::HistoryRecorder,
         if (sim.max_steps === nothing) && (sim.eps === nothing)
             error("If show_progress=true in a HistoryRecorder, you must also specify max_steps or eps.")
         end
-        prog = Progress(max_steps, "Simulating..." )
+        prog = Progress(max_steps; desc="Simulating..." )
     else
         prog = nothing
     end

--- a/lib/POMDPTools/src/Simulators/history_recorder.jl
+++ b/lib/POMDPTools/src/Simulators/history_recorder.jl
@@ -89,7 +89,7 @@ function simulate(sim::HistoryRecorder,
     end
     
     if sim.show_progress
-        if (sim.max_steps == nothing) && (sim.eps == nothing)
+        if (sim.max_steps === nothing) && (sim.eps === nothing)
             error("If show_progress=true in a HistoryRecorder, you must also specify max_steps or eps.")
         end
         prog = Progress(max_steps, "Simulating..." )
@@ -147,7 +147,7 @@ function simulate(sim::HistoryRecorder,
                         max_steps)
 
     if sim.show_progress
-        if (sim.max_steps == nothing) && (sim.eps == nothing)
+        if (sim.max_steps === nothing) && (sim.eps === nothing)
             error("If show_progress=true in a HistoryRecorder, you must also specify max_steps or eps.")
         end
         prog = Progress(max_steps, "Simulating..." )

--- a/lib/POMDPTools/src/Simulators/parallel.jl
+++ b/lib/POMDPTools/src/Simulators/parallel.jl
@@ -119,7 +119,7 @@ end
 will return a dataframe with with the number of steps and the reward in it.
 """
 function run_parallel(process::Function, queue::AbstractVector, pool::AbstractWorkerPool=default_worker_pool();
-                      progress=Progress(length(queue), desc="Simulating..."),
+                      progress=Progress(length(queue); desc="Simulating..."),
                       proc_warn::Bool=true, show_progress::Bool=true)
 
     if nworkers(pool) == 1 && proc_warn

--- a/lib/POMDPTools/src/Simulators/parallel.jl
+++ b/lib/POMDPTools/src/Simulators/parallel.jl
@@ -53,7 +53,7 @@ function Sim(pomdp::POMDP,
              metadata = NamedTuple()
             )
 
-    if initialstate == nothing && statetype(pomdp) != Nothing
+    if initialstate === nothing && statetype(pomdp) != Nothing
         is = rand(rng, initial_belief)
     else
         is = initialstate
@@ -76,7 +76,7 @@ function Sim(mdp::MDP,
              metadata = NamedTuple()
             )
 
-    if initialstate == nothing && statetype(mdp) != Nothing
+    if initialstate === nothing && statetype(mdp) != Nothing
         is = rand(rng, POMDPs.initialstate(mdp))
     else
         is = initialstate
@@ -133,7 +133,7 @@ function run_parallel(process::Function, queue::AbstractVector, pool::AbstractWo
     end
     
     if progress in (nothing, false)
-        progstr = (progress == nothing) ? "nothing" : "false"
+        progstr = (progress === nothing) ? "nothing" : "false"
         @warn("run_parallel(..., progress=$progstr) is deprecated. Use run_parallel(..., show_progress=false) instead.")
         show_progress = false
     end

--- a/lib/POMDPTools/test/simulators/test_history_recorder.jl
+++ b/lib/POMDPTools/test/simulators/test_history_recorder.jl
@@ -21,10 +21,10 @@ r2 = simulate(sim, problem, policy)
 @test length(ainfo_hist(r2)) == steps
 @test length(uinfo_hist(r2)) == steps
 
-@test exception(r1) == nothing
-@test exception(r2) == nothing
-@test backtrace(r1) == nothing
-@test backtrace(r2) == nothing
+@test exception(r1) === nothing
+@test exception(r2) === nothing
+@test backtrace(r1) === nothing
+@test backtrace(r2) === nothing
 
 @test n_steps(r1) == n_steps(r2)
 @test undiscounted_reward(r1) == undiscounted_reward(r2)
@@ -41,7 +41,7 @@ for tuple in r1
 end
 
 for ui in eachstep(r2, "update_info")
-    @test ui == nothing
+    @test ui === nothing
 end
 
 @test r1[1] == first(r1)


### PR DESCRIPTION
- Updated the calls to `Progress` in line with the deprecation warning
- Changed comparisons to `nothing` to use `===` vs `==`

Closes https://github.com/JuliaPOMDP/POMDPs.jl/issues/533