### PR TITLE
Update CI.yml to run weekly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 23 * * 0'  # Runs every Sunday at 11:30 PM
 
 jobs:
   test:


### PR DESCRIPTION
Update CI to run at 11:30 PM every Sunday. 

The main idea is to help us catch issues with failing tests sooner. This likely isn't an issue with this repo as there are frequent changes, but other repos in the JuliaPOMP ecosystem often go months without any tests being run.